### PR TITLE
remove skip statement from testStartLedgerWithoutNewLineAppendedToLastRecord test so that it runs on windows

### DIFF
--- a/ledger/ledger.py
+++ b/ledger/ledger.py
@@ -199,7 +199,7 @@ class Ledger(ImmutableStore):
         lineSep = os.linesep.encode()
         lineSepLength = len(lineSep)
         try:
-            with open(os.path.join(self.dataDir, self._transactionLogName), 'ab+') as f:
+            with open(os.path.join(self.dataDir, self._transactionLogName), 'a+b') as f:
                 size = f.tell()
                 if size > 0:
                     f.seek(-lineSepLength, 2)  # last character in file

--- a/ledger/test/test_ledger.py
+++ b/ledger/test/test_ledger.py
@@ -172,16 +172,12 @@ def testConsistencyVerificationOnStartupCase2(tempdir):
     ledger.stop()
 
 
-<<<<<<< dae149f453f4134948271ebea953e46c2c493678
-
-=======
->>>>>>> [SOV-595] skipped this test for windows, it passes fine on ubuntu, so must be os dependent issue, which will be fixed as part of SOV-595, till then, disabling this test for windows
-@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-595')
 def testStartLedgerWithoutNewLineAppendedToLastRecord(ledger):
     txnStr = '{"data":{"alias":"Node1","client_ip":"127.0.0.1","client_port":9702,"node_ip":"127.0.0.1",' \
            '"node_port":9701,"services":["VALIDATOR"]},"dest":"Gw6pDLhcBcoQesN72qfotTgFa7cbuqZpkX3Xo6pLhPhv",' \
            '"identifier":"FYmoFw55GeQH7SRFa37dkx1d2dZ3zUF8ckg7wmL7ofN4",' \
            '"txnId":"fea82e10e894419fe2bea7d96296a6d46f50f93f9eeda954ec461b2ed2950b62","type":"NODE"}'
+    lineSep = os.linesep.encode()
     ledger.start()
     ledger._transactionLog.put(txnStr)
     ledger._transactionLog.put(txnStr)
@@ -189,7 +185,7 @@ def testStartLedgerWithoutNewLineAppendedToLastRecord(ledger):
     size1 = ledger._transactionLog.numKeys
     assert size1 == 3
     ledger.stop()
-    newLineCounts = open(ledger._transactionLog.dbPath, 'r').read().count(os.linesep) + 1
+    newLineCounts = open(ledger._transactionLog.dbPath, 'rb').read().count(lineSep) + 1
     assert newLineCounts == 3
 
     # now start ledger, and it should add the missing new line char at the end of the file, so
@@ -197,5 +193,5 @@ def testStartLedgerWithoutNewLineAppendedToLastRecord(ledger):
     ledger.start()
     size2 = ledger._transactionLog.numKeys
     assert size2 == size1
-    newLineCountsAferLedgerStart = open(ledger._transactionLog.dbPath, 'r').read().count(os.linesep) + 1
+    newLineCountsAferLedgerStart = open(ledger._transactionLog.dbPath, 'rb').read().count(lineSep) + 1
     assert newLineCountsAferLedgerStart == 4

--- a/ledger/test/test_ledger.py
+++ b/ledger/test/test_ledger.py
@@ -172,7 +172,10 @@ def testConsistencyVerificationOnStartupCase2(tempdir):
     ledger.stop()
 
 
+<<<<<<< dae149f453f4134948271ebea953e46c2c493678
 
+=======
+>>>>>>> [SOV-595] skipped this test for windows, it passes fine on ubuntu, so must be os dependent issue, which will be fixed as part of SOV-595, till then, disabling this test for windows
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-595')
 def testStartLedgerWithoutNewLineAppendedToLastRecord(ledger):
     txnStr = '{"data":{"alias":"Node1","client_ip":"127.0.0.1","client_port":9702,"node_ip":"127.0.0.1",' \


### PR DESCRIPTION
remove skip statement from testStartLedgerWithoutNewLineAppendedToLastRecord test so that it runs on windows