### PR TITLE
Fix usage of _defaultStore in Ledger

### DIFF
--- a/ledger/ledger.py
+++ b/ledger/ledger.py
@@ -190,12 +190,9 @@ class Ledger(ImmutableStore):
             ensureDurability = ensureDurability or self.ensureDurability
             self._transactionLog = \
                 self._customTransactionLogStore or \
-                Ledger._defaultStore(self.dataDir,      # This is wrong, use the code commented below
-                                     self._transactionLogName,
-                                     ensureDurability)
-                # self.__class__._defaultStore(self.dataDir,
-                #                      self._transactionLogName,
-                #                      ensureDurability)
+                self._defaultStore(self.dataDir,
+                                   self._transactionLogName,
+                                   ensureDurability)
             self._transactionLog.appendNewLineIfReq()
 
     def stop(self):


### PR DESCRIPTION
Use self instead of Ledger when calling static method _defaultStore to let it be overridden is subclasses